### PR TITLE
Dirty hotfix to bypass https namespaces issue

### DIFF
--- a/geoportal-patch-autoconf.js
+++ b/geoportal-patch-autoconf.js
@@ -24,12 +24,15 @@ Geoportal.Catalogue.completeConfiguration= function(configuration){
     return Geoportal.Catalogue.oldCompleteConfiguration(configuration);
 };
 
-
 /*
  * Patch réglant le problème de changement de http vers https de certains namespaces
  */
 const originalParseAutoConf = Geoportal.GeoRMHandler.parseAutoConf;
 Geoportal.GeoRMHandler.parseAutoConf = function (keys, aggregateUrl, callback, resp) {
-  resp.data.xml = resp.data.xml.replace(/="https/g, '="http');
+  try {
+    resp.data.xml = resp.data.xml.replace(/="https/g, '="http');
+  } catch (e) {
+    console.error(e);
+  }
   return originalParseAutoConf(keys, aggregateUrl, callback, resp);
 };

--- a/geoportal-patch-autoconf.js
+++ b/geoportal-patch-autoconf.js
@@ -24,3 +24,12 @@ Geoportal.Catalogue.completeConfiguration= function(configuration){
     return Geoportal.Catalogue.oldCompleteConfiguration(configuration);
 };
 
+
+/*
+ * Patch réglant le problème de changement de http vers https de certains namespaces
+ */
+const originalParseAutoConf = Geoportal.GeoRMHandler.parseAutoConf;
+Geoportal.GeoRMHandler.parseAutoConf = function (keys, aggregateUrl, callback, resp) {
+  resp.data.xml = resp.data.xml.replace(/="https/g, '="http');
+  return originalParseAutoConf(keys, aggregateUrl, callback, resp);
+};


### PR DESCRIPTION
Context: https://www.developpez.net/forums/d2013223/applications/sig-systeme-d-information-geographique/ign-api-geoportail/erreur-general-tilematrixsets-is-undefined-patch_autoconf-js/

C'est moche, minimaliste (ça ne gère aucun [cas d'erreur tel que géré dans la code original](https://github.com/opalesurfcasting/api-geoportail-v2/blob/master/lib/geoportal/lib/Geoportal/GeoRMHandler.js#L706)), mais ça fonctionne (du moins, jusqu'à là mise hors ligne définitive de la v2).

C'est largement améliorable (try/catch, regexp, remplacement plus sélectif), mais je n'ai malheureusement pas de temps à y consacrer pour le moment.